### PR TITLE
Update Copernicus API Hub URL

### DIFF
--- a/ost/Project.py
+++ b/ost/Project.py
@@ -225,7 +225,7 @@ class Sentinel1(Generic):
     # ------------------------------------------
     # methods
     def search(self, outfile=OST_INVENTORY_FILE, append=False,
-               base_url='https://scihub.copernicus.eu/apihub'):
+               base_url='https://apihub.copernicus.eu/apihub'):
         """High Level search function
 
         :param outfile:

--- a/ost/helpers/scihub.py
+++ b/ost/helpers/scihub.py
@@ -36,7 +36,7 @@ def ask_credentials():
 
 
 def connect(uname=None, pword=None,
-            base_url='https://scihub.copernicus.eu/apihub'):
+            base_url='https://apihub.copernicus.eu/apihub'):
     """Generates an opener for the Copernicus apihub/dhus
     
 
@@ -187,7 +187,7 @@ def create_s1_product_specs(product_type='*', polarisation='*', beam='*'):
 
 
 def check_connection(uname, pword,
-                     base_url='https://scihub.copernicus.eu/apihub'):
+                     base_url='https://apihub.copernicus.eu/apihub'):
     """Check if a connection with scihub can be established
 
     :param uname:
@@ -215,7 +215,7 @@ def s1_download_parallel(argument_list):
 
 
 def s1_download(uuid, filename, uname, pword,
-                base_url='https://scihub.copernicus.eu/apihub'):
+                base_url='https://apihub.copernicus.eu/apihub'):
     """Single scene download function for Copernicus scihub/apihub
     
     :param uuid: product's uuid
@@ -310,7 +310,7 @@ def s1_download(uuid, filename, uname, pword,
 
 
 def batch_download(inventory_df, download_dir, uname, pword, concurrent=2,
-                   base_url='https://scihub.copernicus.eu/apihub'):
+                   base_url='https://apihub.copernicus.eu/apihub'):
     """Batch download Sentinel-1 on the basis of an OST inventory GeoDataFrame
 
     :param inventory_df:

--- a/ost/helpers/settings.py
+++ b/ost/helpers/settings.py
@@ -184,7 +184,7 @@ GPT_FILE = get_gpt()
 OST_ROOT = Path(importlib.util.find_spec('ost').submodule_search_locations[0])
 
 # set global variable for APIHUB product
-APIHUB_BASEURL = 'https://scihub.copernicus.eu/apihub/odata/v1/Products'
+APIHUB_BASEURL = 'https://apihub.copernicus.eu/apihub/odata/v1/Products'
 # ---------------------------------------------------------------
 
 # ---------------------------------------------------------------

--- a/ost/s1/s1scene.py
+++ b/ost/s1/s1scene.py
@@ -286,7 +286,7 @@ class Sentinel1Scene:
 
         # construct the basic the url
         base_url = (
-            'https://scihub.copernicus.eu/apihub/odata/v1/Products?$filter='
+            'https://apihub.copernicus.eu/apihub/odata/v1/Products?$filter='
         )
 
         # request
@@ -399,7 +399,7 @@ class Sentinel1Scene:
             f'Retrieving URLs of annotation files for S1 product: '
             f'{self.scene_id}.'
         )
-        scihub_url = 'https://scihub.copernicus.eu/apihub/odata/v1/Products'
+        scihub_url = 'https://apihub.copernicus.eu/apihub/odata/v1/Products'
         anno_path = (
             f'(\'{uuid}\')/Nodes(\'{self.scene_id}.SAFE\')'
             f'/Nodes(\'annotation\')/Nodes'

--- a/ost/s1/search.py
+++ b/ost/s1/search.py
@@ -396,7 +396,7 @@ def check_availability(inventory_gdf, download_dir, data_mount):
 
 def scihub_catalogue(query_string, output, append=False,
                      uname=None, pword=None,
-                     base_url='https://scihub.copernicus.eu/apihub'):
+                     base_url='https://apihub.copernicus.eu/apihub'):
     """This is the main search function on scihub
 
     :param query_string:

--- a/tests/test_s1_download.py
+++ b/tests/test_s1_download.py
@@ -34,7 +34,7 @@ def test_esa_scihub_connection(s1_grd_notnr_ost_product):
     control_code = 200
     assert response_code == control_code
     opener = connect(
-        base_url='https://scihub.copernicus.eu/apihub/',
+        base_url='https://apihub.copernicus.eu/apihub/',
         uname=herbert_uname,
         pword=herbert_password
     )


### PR DESCRIPTION
Update to new API Hub URL
see:  https://scihub.copernicus.eu/news/News00868

(server-side 301 redirect causes failing authentication on old URL)