### PR TITLE
Fixed helper vector functions / added weak testing

### DIFF
--- a/ost/helpers/vector.py
+++ b/ost/helpers/vector.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pyproj
 from pyproj.crs import ProjectedCRS
-from pyproj.crs.coordinate_operation import AzumuthalEquidistantConversion
+from pyproj.crs.coordinate_operation import AzimuthalEquidistantConversion
 import geopandas as gpd
 import logging
 
@@ -183,7 +183,7 @@ def geodesic_point_buffer(lon, lat, meters, envelope=False):
     """
 
     proj_crs = ProjectedCRS(
-        conversion=AzumuthalEquidistantConversion(float(lat), float(lon))
+        conversion=AzimuthalEquidistantConversion(float(lat), float(lon))
     )
 
     proj_wgs84 = pyproj.Proj('EPSG:4326')

--- a/ost/helpers/vector.py
+++ b/ost/helpers/vector.py
@@ -63,8 +63,8 @@ def aoi_to_wkt(aoi):
         try:
             # let's check if it is a shapely readable WKT
             world = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))
-            aoi_wkt = world['geometry'][world['iso_a3'] == aoi].values[0].to_wkt()
-
+            aoi_wkt = world['geometry'][world['iso_a3'] == aoi].values[0].wkt
+            
         except IndexError:
             # see if it is a Geovector file
             if Path(aoi).exists():
@@ -239,7 +239,7 @@ def latlon_to_wkt(
         if envelope:
             aoi_geom = aoi_geom.envelope
 
-        aoi_wkt = aoi_geom.to_wkt()
+        aoi_wkt = aoi_geom.wkt
 
     elif buffer_meter:
         aoi_wkt = geodesic_point_buffer(lon, lat, buffer_meter, envelope)

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -1,0 +1,35 @@
+import os
+import sys
+
+
+import shapely 
+
+sys.path.append(os.getcwd())
+from ost.helpers import vector 
+
+# test aoi_to_wkt
+aoi = vector.aoi_to_wkt('IRL')
+assert (type(aoi) == str and aoi.startswith('POLYGON'))
+
+aoi = vector.aoi_to_wkt('POLYGON((1 2,1 4,3 4,3 2,1 2))')
+assert (type(aoi) == str and aoi.startswith('POLYGON'))
+
+aoi = vector.aoi_to_wkt('tests/testdata/test_polygon.geojson')
+assert (type(aoi) == str and aoi.startswith('POLYGON'))
+
+# test latlon_to_wkt
+lat, lon = '-67', '-61'
+aoi = vector.latlon_to_wkt(lat, lon)
+assert (type(aoi) == str and aoi.startswith('POINT'))
+
+aoi = vector.latlon_to_wkt(lat, lon, buffer_degree=1)
+assert (type(aoi) == str and aoi.startswith('POLYGON'))
+
+aoi = vector.latlon_to_wkt(lat, lon, buffer_degree=1, envelope=False)
+assert (type(aoi) == str and aoi.startswith('POLYGON'))
+
+aoi = vector.latlon_to_wkt(lat, lon, buffer_degree=1, envelope=True)
+assert (type(aoi) == str and aoi.startswith('POLYGON'))
+
+aoi = vector.latlon_to_wkt(lat, lon, buffer_meter=1000, envelope=True)
+assert (type(aoi) == str and aoi.startswith('POLYGON'))

--- a/tests/testdata/test_polygon.geojson
+++ b/tests/testdata/test_polygon.geojson
@@ -1,0 +1,8 @@
+{
+"type": "FeatureCollection",
+"name": "test_polygon",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+"features": [
+{ "type": "Feature", "properties": { }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -62.642260990940358, -9.144642335372852 ], [ -62.644538612626853, -9.656964044353968 ], [ -61.984028323546326, -9.643491691704158 ], [ -62.025025513903039, -9.155885526454442 ], [ -62.642260990940358, -9.144642335372852 ] ] ] } }
+]
+}


### PR DESCRIPTION
So, for context, neither `aoi_to_wkt` nor `latlon_to_wkt` were working in the example notebooks, because of shapely using `.wkt` instead of `.to_wkt()` to convert polygons to wkt strings. 

I also fixed a deprecation warning with pyproj, and added some tests for the vector functions. For this I took the liberty of adding a small geojson to the test files, let me know if I should kill it.

Cheers,
K.