### PR TITLE
Change README.md to README.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 HERE = pathlib.Path(__file__).parent
 
 # The text of the README file
-README = (HERE / "README.md").read_text()
+README = (HERE / "README.rst").read_text()
 
 setup(
     name='opensartoolkit',


### PR DESCRIPTION
pip installing from github is broken, I believe because we changed the readme format from md to rst.