### PR TITLE
build: Commitizen implementation

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -1,0 +1,9 @@
+commitizen:
+  name: cz_conventional_commits
+  changelog_file: CHANGELOG.md
+  tag_format: $major.$minor.$patch$prerelease
+  version: 0.12.5
+  version_files:
+  - setup.py:version
+  - ost/__init__.py:__version__
+  

--- a/.flake8
+++ b/.flake8
@@ -2,3 +2,6 @@
 # E501: line too long | Black take care of it
 # W503: line break before binary operator | Black take care of it
 ignore = E501, W503
+
+# conf have funny importing structure
+exclude = docs/source/conf.py

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,30 @@
+name: Bump version
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  bump-version:
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
+    runs-on: ubuntu-latest
+    name: "Bump version and create changelog with commitizen"
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+        with:
+          token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
+          fetch-depth: 0
+      - name: Create bump and changelog
+        uses: commitizen-tools/commitizen-action@master
+        with:
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          changelog_increment_filename: body.md
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: "body.md"
+          tag_name: ${{ env.REVISION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pipy_release.yml
+++ b/.github/workflows/pipy_release.yml
@@ -1,12 +1,13 @@
 name: Upload Python Package
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - "*"
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,18 +8,19 @@ Following these guidelines helps to communicate that you respect the time of the
 
 .. warning:: 
 
-  Please, don't use the issue tracker for **support questions**. Instead, check if `discussion channels <https://github.com/ESA-PhiLab/OpenSarToolkit/discussions>`__ can help with your issue. 
+    Please, don't use the issue tracker for **support questions**. Instead, check if `discussion channels <https://github.com/ESA-PhiLab/OpenSarToolkit/discussions>`__ can help with your issue. 
 
 Ground Rules
 ------------
 
-**Responsibilities**
-#. Ensure cross-platform compatibility for every change that's accepted. Windows, Mac, Debian & Ubuntu Linux.
-#. Ensure that code that goes into core meets all requirements in the commitizen checklist
-#. Create issues for any major changes and enhancements that you wish to make. Discuss things transparently and get community feedback.
-#. Don't add any classes to the codebase unless absolutely needed. Err on the side of using functions.
-#. Keep feature versions as small as possible, preferably one new feature per version.
-#. Be welcoming to newcomers and encourage diverse new contributors from all backgrounds. See our `Code of Conduct <https://github.com/ESA-PhiLab/OpenSarToolkit/blob/main/CODE_OF_CONDUCT.md>`__.
+**Responsibilities**:
+
+#.  Ensure cross-platform compatibility for every change that's accepted. Windows, Mac, Debian & Ubuntu Linux.
+#.  Ensure that code that goes into core meets all requirements in the commitizen checklist
+#.  Create issues for any major changes and enhancements that you wish to make. Discuss things transparently and get community feedback.
+#.  Don't add any classes to the codebase unless absolutely needed. Err on the side of using functions.
+#.  Keep feature versions as small as possible, preferably one new feature per version.
+#.  Be welcoming to newcomers and encourage diverse new contributors from all backgrounds. See our `Code of Conduct <https://github.com/ESA-PhiLab/OpenSarToolkit/blob/main/CODE_OF_CONDUCT.md>`__.
 
 Your First Contribution
 -----------------------
@@ -35,8 +36,7 @@ Report a bug
 ^^^^^^^^^^^^
 .. danger:: 
 
-  If you find a security vulnerability, do NOT open an issue. Email opensarkit@gmail.com instead.
-
+    If you find a security vulnerability, do NOT open an issue. Email opensarkit@gmail.com instead.
 
 When filing an issue, make sure to answer the questions predifined in the issue template, it will help us reproduce the bug and elp you debuging it.
 
@@ -49,37 +49,70 @@ To install the development environment of the :code:`OpenSarToolkit` lib, create
 
 .. code-block:: console
 
-  $ cd OpenSarToolkit
-  $ python -m venv venv
-  (venv)$ source venv/bin/activate
+    $ cd OpenSarToolkit
+    $ python -m venv venv
+    (venv)$ source venv/bin/activate
   
 Once in the venv, you can install :code:`GDAL` (https://pypi.org/project/GDAL/) :code:`SNAP` (http://step.esa.int/main/download/) and :code:`ORFEO` (https://www.orfeo-toolbox.org/download/). then install the lib in development mode:
 
 .. code-block:: console
 
-  $ pip install -e .[dev]
+    $ pip install -e .[dev]
   
 This will install the :code:`pre-commit` hooks that will be run each time you commit to the repository.
 
 .. note:: 
 
-  You are not force to use en :code:`venv` to run :code:`ost` but make sure that your dependencies are compatible
+    You are not force to use en :code:`venv` to run :code:`ost` but make sure that your dependencies are compatible
 
 pull request
 ^^^^^^^^^^^^
+
 For something that is bigger than a one or two line fix
 
-#. Create your own fork of the code
-#. Do the changes in your fork
-#. If you like the change and think the project could use it:
+#.  Create your own fork of the code
+#.  Do the changes in your fork
+#.  If you like the change and think the project could use it:
 
-   * Be sure you have followed the code style for the project.
-   * run the test suit by running in the root folder of the lib:
+    *   Be sure you have followed the code style for the project.
+    *   run the test suit by running in the root folder of the lib:
     
-     .. code-block:: 
+        .. code-block:: 
     
-         python -m pytest
+            python -m pytest
          
-   * Send a pull request using the provided template
+    *   Send a pull request using the provided template
+
+Release
+^^^^^^^
+
+.. danger:: 
+
+    This section is intended for maintainer only, if a PR contains commit starting with "bump:" they will be refused.
+
+
+To publish an OST new version: 
+
+-   Wait for the test to run and complete on :code:`main`
+-   run the commitizen command locally 
+  
+    .. code-block::
+
+        cz bump
+  
+    You will see on your screen something like: 
+
+    .. code-block:: console
+
+        bump: version 0.12.5 → 0.12.6
+        tag to create: 0.12.6
+        increment detected: PATCH
+
+-   Push to main (the commit is already created by the :code:`cz bump` command)
+-   Monitor the Github actions
+    
+    #.   create a changelog 
+    #.   create a release with the new version name and corresponding changelog body
+    #.   publish to pipy
    
 ✨ Happy contribuing ! ✨

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,19 +12,22 @@
 #
 import os
 import sys
+from datetime import datetime
 
 sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath("../.."))  # to have access to import ost
+
+import ost
 
 
 # -- Project information -----------------------------------------------------
 
 project = "OpenSarToolkit"
-copyright = "2021, Andreas Vollrath"
-author = "Andreas Vollrath"
+copyright = f"2016-{datetime.now().year}, {ost.__author__}"
+author = ost.__author__
 
 # The full version, including alpha/beta/rc tags
-release = "0.12.5"
+release = ost.__version__
 
 
 # -- General configuration ---------------------------------------------------

--- a/ost/__init__.py
+++ b/ost/__init__.py
@@ -2,3 +2,7 @@ from ost.s1.s1scene import Sentinel1Scene
 from ost.Project import Generic, Sentinel1, Sentinel1Batch
 
 __all__ = ["Sentinel1Scene", "Sentinel1Batch", "Sentinel1", "Generic"]
+
+__author__ = "Andreas Vollrath"
+__email__ = "opensarkit@gmail.com"
+__version__ = "0.12.5"

--- a/setup.py
+++ b/setup.py
@@ -97,10 +97,8 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering :: GIS",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
             "nbsphinx",
             "pydata-sphinx-theme",
             "sphinx-copybutton",
+            "Commitizen",
         ]
     },
     cmdclass={"develop": DevelopCmd},


### PR DESCRIPTION
- [x] create a commitizen environment 
- [x] create a github action workflow:
  - locally run `cz bump`
  - push to main 
  - triggers everything in this order -> bump tag -> bump changelog -> create Github release -> create pipy release
- [x] document the release process in the doc 

I folowed the requirements from https://commitizen-tools.github.io/commitizen/tutorials/github_actions/
It still need to be tested with an administrator of the repository as it request 2 extra `secrets` environment variables