### PR TITLE
avoid skipping of first argument in module functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # macOS
 .DS_Store
+
+# IDE 
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "restructuredtext.confPath": ""
-}

--- a/docs/source/modules/ost.generic.ard_to_ts.rst
+++ b/docs/source/modules/ost.generic.ard_to_ts.rst
@@ -11,9 +11,9 @@ ost.generic.ard\_to\_ts
       ard_to_ts
       gd_ard_to_ts
 
-.. automethod:: ost.generic.ard_to_ts.ard_to_ts
+.. autofunction:: ost.generic.ard_to_ts.ard_to_ts
 
-.. automethod:: ost.generic.ard_to_ts.gd_ard_to_ts
+.. autofunction:: ost.generic.ard_to_ts.gd_ard_to_ts
 
 
    

--- a/docs/source/modules/ost.generic.common_wrappers.rst
+++ b/docs/source/modules/ost.generic.common_wrappers.rst
@@ -16,19 +16,19 @@ ost.generic.common\_wrappers
       terrain_correction
       terrain_flattening
 
-.. automethod:: ost.generic.common_wrappers.create_stack
+.. autofunction:: ost.generic.common_wrappers.create_stack
 
-.. automethod:: ost.generic.common_wrappers.linear_to_db
+.. autofunction:: ost.generic.common_wrappers.linear_to_db
 
-.. automethod:: ost.generic.common_wrappers.ls_mask
+.. autofunction:: ost.generic.common_wrappers.ls_mask
 
-.. automethod:: ost.generic.common_wrappers.mt_speckle_filter
+.. autofunction:: ost.generic.common_wrappers.mt_speckle_filter
 
-.. automethod:: ost.generic.common_wrappers.speckle_filter
+.. autofunction:: ost.generic.common_wrappers.speckle_filter
 
-.. automethod:: ost.generic.common_wrappers.terrain_correction
+.. autofunction:: ost.generic.common_wrappers.terrain_correction
 
-.. automethod:: ost.generic.common_wrappers.terrain_flattening
+.. autofunction:: ost.generic.common_wrappers.terrain_flattening
 
    
    

--- a/docs/source/modules/ost.generic.mosaic.rst
+++ b/docs/source/modules/ost.generic.mosaic.rst
@@ -14,15 +14,15 @@ ost.generic.mosaic
       mosaic
       mosaic_slc_acquisition
 
-.. automethod:: ost.generic.mosaic.create_timeseries_mosaic_vrt
+.. autofunction:: ost.generic.mosaic.create_timeseries_mosaic_vrt
 
-.. automethod:: ost.generic.mosaic.gd_mosaic
+.. autofunction:: ost.generic.mosaic.gd_mosaic
 
-.. automethod:: ost.generic.mosaic.gd_mosaic_slc_acquisition
+.. autofunction:: ost.generic.mosaic.gd_mosaic_slc_acquisition
 
-.. automethod:: ost.generic.mosaic.mosaic
+.. autofunction:: ost.generic.mosaic.mosaic
 
-.. automethod:: ost.generic.mosaic.mosaic_slc_acquisition
+.. autofunction:: ost.generic.mosaic.mosaic_slc_acquisition
    
    
 

--- a/docs/source/modules/ost.generic.timescan.rst
+++ b/docs/source/modules/ost.generic.timescan.rst
@@ -16,19 +16,19 @@ ost.generic.timescan
       nan_percentile
       remove_outliers
 
-.. automethod:: ost.generic.timescan.date_as_float
+.. autofunction:: ost.generic.timescan.date_as_float
 
-.. automethod:: ost.generic.timescan.deseasonalize
+.. autofunction:: ost.generic.timescan.deseasonalize
 
-.. automethod:: ost.generic.timescan.difference_in_years
+.. autofunction:: ost.generic.timescan.difference_in_years
 
-.. automethod:: ost.generic.timescan.gd_mt_metrics
+.. autofunction:: ost.generic.timescan.gd_mt_metrics
 
-.. automethod:: ost.generic.timescan.mt_metrics
+.. autofunction:: ost.generic.timescan.mt_metrics
 
-.. automethod:: ost.generic.timescan.nan_percentile
+.. autofunction:: ost.generic.timescan.nan_percentile
 
-.. automethod:: ost.generic.timescan.remove_outliers
+.. autofunction:: ost.generic.timescan.remove_outliers
    
    
 

--- a/docs/source/modules/ost.generic.ts_extent.rst
+++ b/docs/source/modules/ost.generic.ts_extent.rst
@@ -10,7 +10,7 @@ ost.generic.ts\_extent
    
       mt_extent
 
-.. automethod:: ost.generic.ts_extent.mt_extent
+.. autofunction:: ost.generic.ts_extent.mt_extent
    
    
 

--- a/docs/source/modules/ost.generic.ts_ls_mask.rst
+++ b/docs/source/modules/ost.generic.ts_ls_mask.rst
@@ -10,4 +10,4 @@ ost.generic.ts\_ls\_mask
    
       mt_layover
 
-.. automethod:: ost.generic.ts_ls_mask.mt_layover
+.. autofunction:: ost.generic.ts_ls_mask.mt_layover

--- a/docs/source/modules/ost.helpers.asf.rst
+++ b/docs/source/modules/ost.helpers.asf.rst
@@ -14,15 +14,15 @@ ost.helpers.asf
       batch_download
       check_connection
 
-.. automethod:: ost.helpers.asf.asf_download
+.. autofunction:: ost.helpers.asf.asf_download
 
-.. automethod:: ost.helpers.asf.asf_download_parallel
+.. autofunction:: ost.helpers.asf.asf_download_parallel
 
-.. automethod:: ost.helpers.asf.ask_credentials
+.. autofunction:: ost.helpers.asf.ask_credentials
 
-.. automethod:: ost.helpers.asf.batch_download
+.. autofunction:: ost.helpers.asf.batch_download
 
-.. automethod:: ost.helpers.asf.check_connection
+.. autofunction:: ost.helpers.asf.check_connection
    
    
 

--- a/docs/source/modules/ost.helpers.asf_wget.rst
+++ b/docs/source/modules/ost.helpers.asf_wget.rst
@@ -20,11 +20,11 @@ ost.helpers.asf\_wget
 
       SessionWithHeaderRedirection
 
-.. automethod:: ost.helpers.asf_wget.batch_download
+.. autofunction:: ost.helpers.asf_wget.batch_download
 
-.. automethod:: ost.helpers.asf_wget.check_connection
+.. autofunction:: ost.helpers.asf_wget.check_connection
 
-.. automethod:: ost.helpers.asf_wget.s1_download
+.. autofunction:: ost.helpers.asf_wget.s1_download
    
    
 

--- a/docs/source/modules/ost.helpers.db.rst
+++ b/docs/source/modules/ost.helpers.db.rst
@@ -18,7 +18,7 @@ ost.helpers.db
 
       pgConnect
 
-.. automethod:: ost.helpers.db.pgHandler
+.. autofunction:: ost.helpers.db.pgHandler
 
 
 

--- a/docs/source/modules/ost.helpers.errors.rst
+++ b/docs/source/modules/ost.helpers.errors.rst
@@ -12,11 +12,11 @@ ost.helpers.errors
       GPTRuntimeError
       NotValidFileError
 
-.. automethod:: ost.helpers.errors.DownloadError
+.. autofunction:: ost.helpers.errors.DownloadError
 
-.. automethod:: ost.helpers.errors.GPTRuntimeError
+.. autofunction:: ost.helpers.errors.GPTRuntimeError
 
-.. automethod:: ost.helpers.errors.NotValidFileError
+.. autofunction:: ost.helpers.errors.NotValidFileError
 
 
    

--- a/docs/source/modules/ost.helpers.helpers.rst
+++ b/docs/source/modules/ost.helpers.helpers.rst
@@ -19,25 +19,25 @@ ost.helpers.helpers
       run_command
       timer
 
-.. automethod:: ost.helpers.helpers.check_out_dimap
+.. autofunction:: ost.helpers.helpers.check_out_dimap
 
-.. automethod:: ost.helpers.helpers.check_out_tiff
+.. autofunction:: ost.helpers.helpers.check_out_tiff
 
-.. automethod:: ost.helpers.helpers.check_zipfile
+.. autofunction:: ost.helpers.helpers.check_zipfile
 
-.. automethod:: ost.helpers.helpers.delete_dimap
+.. autofunction:: ost.helpers.helpers.delete_dimap
 
-.. automethod:: ost.helpers.helpers.delete_shapefile
+.. autofunction:: ost.helpers.helpers.delete_shapefile
 
-.. automethod:: ost.helpers.helpers.move_dimap
+.. autofunction:: ost.helpers.helpers.move_dimap
 
-.. automethod:: ost.helpers.helpers.remove_folder_content
+.. autofunction:: ost.helpers.helpers.remove_folder_content
 
-.. automethod:: ost.helpers.helpers.resolution_in_degree
+.. autofunction:: ost.helpers.helpers.resolution_in_degree
 
-.. automethod:: ost.helpers.helpers.run_command
+.. autofunction:: ost.helpers.helpers.run_command
 
-.. automethod:: ost.helpers.helpers.timer
+.. autofunction:: ost.helpers.helpers.timer
    
    
 

--- a/docs/source/modules/ost.helpers.onda.rst
+++ b/docs/source/modules/ost.helpers.onda.rst
@@ -14,15 +14,15 @@ ost.helpers.onda
       connect
       onda_download
 
-.. automethod:: ost.helpers.onda.ask_credentials
+.. autofunction:: ost.helpers.onda.ask_credentials
 
-.. automethod:: ost.helpers.onda.batch_download
+.. autofunction:: ost.helpers.onda.batch_download
 
-.. automethod:: ost.helpers.onda.check_connection
+.. autofunction:: ost.helpers.onda.check_connection
 
-.. automethod:: ost.helpers.onda.connect
+.. autofunction:: ost.helpers.onda.connect
 
-.. automethod:: ost.helpers.onda.onda_download
+.. autofunction:: ost.helpers.onda.onda_download
    
    
 

--- a/docs/source/modules/ost.helpers.peps.rst
+++ b/docs/source/modules/ost.helpers.peps.rst
@@ -14,15 +14,15 @@ ost.helpers.peps
       connect
       peps_download
 
-.. automethod:: ost.helpers.peps.ask_credentials
+.. autofunction:: ost.helpers.peps.ask_credentials
 
-.. automethod:: ost.helpers.peps.batch_download
+.. autofunction:: ost.helpers.peps.batch_download
 
-.. automethod:: ost.helpers.peps.check_connection
+.. autofunction:: ost.helpers.peps.check_connection
 
-.. automethod:: ost.helpers.peps.connect
+.. autofunction:: ost.helpers.peps.connect
 
-.. automethod:: ost.helpers.peps.peps_download
+.. autofunction:: ost.helpers.peps.peps_download
    
    
 

--- a/docs/source/modules/ost.helpers.raster.rst
+++ b/docs/source/modules/ost.helpers.raster.rst
@@ -29,45 +29,45 @@ ost.helpers.raster
       stretch_to_8bit
       visualise_rgb
 
-.. automethod:: ost.helpers.raster.calc_max
+.. autofunction:: ost.helpers.raster.calc_max
 
-.. automethod:: ost.helpers.raster.calc_min
+.. autofunction:: ost.helpers.raster.calc_min
 
-.. automethod:: ost.helpers.raster.combine_timeseries
+.. autofunction:: ost.helpers.raster.combine_timeseries
 
-.. automethod:: ost.helpers.raster.convert_to_db
+.. autofunction:: ost.helpers.raster.convert_to_db
 
-.. automethod:: ost.helpers.raster.create_rgb_jpeg
+.. autofunction:: ost.helpers.raster.create_rgb_jpeg
 
-.. automethod:: ost.helpers.raster.create_timeseries_animation
+.. autofunction:: ost.helpers.raster.create_timeseries_animation
 
-.. automethod:: ost.helpers.raster.create_tscan_vrt
+.. autofunction:: ost.helpers.raster.create_tscan_vrt
 
-.. automethod:: ost.helpers.raster.fill_internal_nans
+.. autofunction:: ost.helpers.raster.fill_internal_nans
 
-.. automethod:: ost.helpers.raster.get_max
+.. autofunction:: ost.helpers.raster.get_max
 
-.. automethod:: ost.helpers.raster.get_min
+.. autofunction:: ost.helpers.raster.get_min
 
-.. automethod:: ost.helpers.raster.image_bounds
+.. autofunction:: ost.helpers.raster.image_bounds
 
-.. automethod:: ost.helpers.raster.mask_by_shape
+.. autofunction:: ost.helpers.raster.mask_by_shape
 
-.. automethod:: ost.helpers.raster.norm
+.. autofunction:: ost.helpers.raster.norm
 
-.. automethod:: ost.helpers.raster.outline
+.. autofunction:: ost.helpers.raster.outline
 
-.. automethod:: ost.helpers.raster.polygonize_bounds
+.. autofunction:: ost.helpers.raster.polygonize_bounds
 
-.. automethod:: ost.helpers.raster.polygonize_ls
+.. autofunction:: ost.helpers.raster.polygonize_ls
 
-.. automethod:: ost.helpers.raster.rescale_to_float
+.. autofunction:: ost.helpers.raster.rescale_to_float
 
-.. automethod:: ost.helpers.raster.scale_to_int
+.. autofunction:: ost.helpers.raster.scale_to_int
 
-.. automethod:: ost.helpers.raster.stretch_to_8bit
+.. autofunction:: ost.helpers.raster.stretch_to_8bit
 
-.. automethod:: ost.helpers.raster.visualise_rgb
+.. autofunction:: ost.helpers.raster.visualise_rgb
 
    
    

--- a/docs/source/modules/ost.helpers.scihub.rst
+++ b/docs/source/modules/ost.helpers.scihub.rst
@@ -20,27 +20,27 @@ ost.helpers.scihub
       s1_download
       s1_download_parallel
 
-.. automethod:: ost.helpers.scihub.ask_credentials
+.. autofunction:: ost.helpers.scihub.ask_credentials
 
-.. automethod:: ost.helpers.scihub.batch_download
+.. autofunction:: ost.helpers.scihub.batch_download
 
-.. automethod:: ost.helpers.scihub.check_connection
+.. autofunction:: ost.helpers.scihub.check_connection
 
-.. automethod:: ost.helpers.scihub.connect
+.. autofunction:: ost.helpers.scihub.connect
 
-.. automethod:: ost.helpers.scihub.create_aoi_str
+.. autofunction:: ost.helpers.scihub.create_aoi_str
 
-.. automethod:: ost.helpers.scihub.create_s1_product_specs
+.. autofunction:: ost.helpers.scihub.create_s1_product_specs
 
-.. automethod:: ost.helpers.scihub.create_satellite_string
+.. autofunction:: ost.helpers.scihub.create_satellite_string
 
-.. automethod:: ost.helpers.scihub.create_toi_str
+.. autofunction:: ost.helpers.scihub.create_toi_str
 
-.. automethod:: ost.helpers.scihub.next_page
+.. autofunction:: ost.helpers.scihub.next_page
 
-.. automethod:: ost.helpers.scihub.s1_download
+.. autofunction:: ost.helpers.scihub.s1_download
 
-.. automethod:: ost.helpers.scihub.s1_download_parallel
+.. autofunction:: ost.helpers.scihub.s1_download_parallel
 
    
    

--- a/docs/source/modules/ost.helpers.settings.rst
+++ b/docs/source/modules/ost.helpers.settings.rst
@@ -16,19 +16,19 @@ ost.helpers.settings
       set_log_level
       setup_logfile
 
-.. automethod:: ost.helpers.settings.check_ard_parameters
+.. autofunction:: ost.helpers.settings.check_ard_parameters
 
-.. automethod:: ost.helpers.settings.check_value
+.. autofunction:: ost.helpers.settings.check_value
 
-.. automethod:: ost.helpers.settings.exception_handler
+.. autofunction:: ost.helpers.settings.exception_handler
 
-.. automethod:: ost.helpers.settings.generate_access_file
+.. autofunction:: ost.helpers.settings.generate_access_file
 
-.. automethod:: ost.helpers.settings.get_gpt
+.. autofunction:: ost.helpers.settings.get_gpt
 
-.. automethod:: ost.helpers.settings.set_log_level
+.. autofunction:: ost.helpers.settings.set_log_level
 
-.. automethod:: ost.helpers.settings.setup_logfile
+.. autofunction:: ost.helpers.settings.setup_logfile
 
 
    

--- a/docs/source/modules/ost.helpers.srtm.rst
+++ b/docs/source/modules/ost.helpers.srtm.rst
@@ -11,9 +11,9 @@ ost.helpers.srtm
       download_srtm
       download_srtm_tile
 
-.. automethod:: ost.helpers.srtm.download_srtm
+.. autofunction:: ost.helpers.srtm.download_srtm
 
-.. automethod:: ost.helpers.srtm.download_srtm_tile
+.. autofunction:: ost.helpers.srtm.download_srtm_tile
    
    
 

--- a/docs/source/modules/ost.helpers.vector.rst
+++ b/docs/source/modules/ost.helpers.vector.rst
@@ -26,37 +26,37 @@ ost.helpers.vector
       wkt_manipulations
       wkt_to_gdf
 
-.. automethod:: ost.helpers.vector.aoi_to_wkt
+.. autofunction:: ost.helpers.vector.aoi_to_wkt
 
-.. automethod:: ost.helpers.vector.buffer_shape
+.. autofunction:: ost.helpers.vector.buffer_shape
 
-.. automethod:: ost.helpers.vector.difference
+.. autofunction:: ost.helpers.vector.difference
 
-.. automethod:: ost.helpers.vector.epsg_to_wkt_projection
+.. autofunction:: ost.helpers.vector.epsg_to_wkt_projection
 
-.. automethod:: ost.helpers.vector.exterior
+.. autofunction:: ost.helpers.vector.exterior
 
-.. automethod:: ost.helpers.vector.gdf_to_json_geometry
+.. autofunction:: ost.helpers.vector.gdf_to_json_geometry
 
-.. automethod:: ost.helpers.vector.geodesic_point_buffer
+.. autofunction:: ost.helpers.vector.geodesic_point_buffer
 
-.. automethod:: ost.helpers.vector.get_epsg
+.. autofunction:: ost.helpers.vector.get_epsg
 
-.. automethod:: ost.helpers.vector.get_proj4
+.. autofunction:: ost.helpers.vector.get_proj4
 
-.. automethod:: ost.helpers.vector.latlon_to_shp
+.. autofunction:: ost.helpers.vector.latlon_to_shp
 
-.. automethod:: ost.helpers.vector.plot_inventory
+.. autofunction:: ost.helpers.vector.plot_inventory
 
-.. automethod:: ost.helpers.vector.reproject_geometry
+.. autofunction:: ost.helpers.vector.reproject_geometry
 
-.. automethod:: ost.helpers.vector.set_subset
+.. autofunction:: ost.helpers.vector.set_subset
 
-.. automethod:: ost.helpers.vector.shp_to_wkt
+.. autofunction:: ost.helpers.vector.shp_to_wkt
 
-.. automethod:: ost.helpers.vector.wkt_manipulations
+.. autofunction:: ost.helpers.vector.wkt_manipulations
 
-.. automethod:: ost.helpers.vector.wkt_to_gdf
+.. autofunction:: ost.helpers.vector.wkt_to_gdf
    
    
 

--- a/docs/source/modules/ost.s1.burst_batch.rst
+++ b/docs/source/modules/ost.s1.burst_batch.rst
@@ -15,17 +15,17 @@ ost.s1.burst\_batch
       mosaic_timeseries
       timeseries_to_timescan
 
-.. automethod:: ost.s1.burst_batch.ards_to_timeseries
+.. autofunction:: ost.s1.burst_batch.ards_to_timeseries
 
-.. automethod:: ost.s1.burst_batch.bursts_to_ards
+.. autofunction:: ost.s1.burst_batch.bursts_to_ards
 
-.. automethod:: ost.s1.burst_batch.mosaic_timescan
+.. autofunction:: ost.s1.burst_batch.mosaic_timescan
 
-.. automethod:: ost.s1.burst_batch.mosaic_timescan_old
+.. autofunction:: ost.s1.burst_batch.mosaic_timescan_old
 
-.. automethod:: ost.s1.burst_batch.mosaic_timeseries
+.. autofunction:: ost.s1.burst_batch.mosaic_timeseries
 
-.. automethod:: ost.s1.burst_batch.timeseries_to_timescan
+.. autofunction:: ost.s1.burst_batch.timeseries_to_timescan
    
    
 

--- a/docs/source/modules/ost.s1.burst_inventory.rst
+++ b/docs/source/modules/ost.s1.burst_inventory.rst
@@ -13,13 +13,13 @@ ost.s1.burst\_inventory
       prepare_burst_inventory
       refine_burst_inventory
 
-.. automethod:: ost.s1.burst_inventory.burst_extract
+.. autofunction:: ost.s1.burst_inventory.burst_extract
 
-.. automethod:: ost.s1.burst_inventory.burst_inventory
+.. autofunction:: ost.s1.burst_inventory.burst_inventory
 
-.. automethod:: ost.s1.burst_inventory.prepare_burst_inventory
+.. autofunction:: ost.s1.burst_inventory.prepare_burst_inventory
 
-.. automethod:: ost.s1.burst_inventory.refine_burst_inventory
+.. autofunction:: ost.s1.burst_inventory.refine_burst_inventory
    
    
 

--- a/docs/source/modules/ost.s1.burst_to_ard.rst
+++ b/docs/source/modules/ost.s1.burst_to_ard.rst
@@ -13,13 +13,13 @@ ost.s1.burst\_to\_ard
       create_coherence_layers
       create_polarimetric_layers
 
-.. automethod:: ost.s1.burst_to_ard.burst_to_ard
+.. autofunction:: ost.s1.burst_to_ard.burst_to_ard
 
-.. automethod:: ost.s1.burst_to_ard.create_backscatter_layers
+.. autofunction:: ost.s1.burst_to_ard.create_backscatter_layers
 
-.. automethod:: ost.s1.burst_to_ard.create_coherence_layers
+.. autofunction:: ost.s1.burst_to_ard.create_coherence_layers
 
-.. automethod:: ost.s1.burst_to_ard.create_polarimetric_layers
+.. autofunction:: ost.s1.burst_to_ard.create_polarimetric_layers
    
    
 

--- a/docs/source/modules/ost.s1.download.rst
+++ b/docs/source/modules/ost.s1.download.rst
@@ -11,9 +11,9 @@ ost.s1.download
       download_sentinel1
       restore_download_dir
 
-.. automethod:: ost.s1.download.download_sentinel1
+.. autofunction:: ost.s1.download.download_sentinel1
 
-.. automethod:: ost.s1.download.restore_download_dir
+.. autofunction:: ost.s1.download.restore_download_dir
    
 
    

--- a/docs/source/modules/ost.s1.grd_batch.rst
+++ b/docs/source/modules/ost.s1.grd_batch.rst
@@ -15,17 +15,17 @@ ost.s1.grd\_batch
       mosaic_timeseries
       timeseries_to_timescan
 
-.. automethod:: ost.s1.grd_batch.ards_to_timeseries
+.. autofunction:: ost.s1.grd_batch.ards_to_timeseries
 
-.. automethod:: ost.s1.grd_batch.create_processed_df
+.. autofunction:: ost.s1.grd_batch.create_processed_df
 
-.. automethod:: ost.s1.grd_batch.grd_to_ard_batch
+.. autofunction:: ost.s1.grd_batch.grd_to_ard_batch
 
-.. automethod:: ost.s1.grd_batch.mosaic_timescan
+.. autofunction:: ost.s1.grd_batch.mosaic_timescan
 
-.. automethod:: ost.s1.grd_batch.mosaic_timeseries
+.. autofunction:: ost.s1.grd_batch.mosaic_timeseries
 
-.. automethod:: ost.s1.grd_batch.timeseries_to_timescan
+.. autofunction:: ost.s1.grd_batch.timeseries_to_timescan
 
 
    

--- a/docs/source/modules/ost.s1.grd_to_ard.rst
+++ b/docs/source/modules/ost.s1.grd_to_ard.rst
@@ -11,9 +11,9 @@ ost.s1.grd\_to\_ard
       ard_to_rgb
       grd_to_ard
 
-.. automethod:: ost.s1.grd_to_ard.ard_to_rgb
+.. autofunction:: ost.s1.grd_to_ard.ard_to_rgb
 
-.. automethod:: ost.s1.grd_to_ard.grd_to_ard
+.. autofunction:: ost.s1.grd_to_ard.grd_to_ard
    
    
 

--- a/docs/source/modules/ost.s1.grd_wrappers.rst
+++ b/docs/source/modules/ost.s1.grd_wrappers.rst
@@ -15,17 +15,17 @@ ost.s1.grd\_wrappers
       multi_look
       slice_assembly
 
-.. automethod:: ost.s1.grd_wrappers.calibration
+.. autofunction:: ost.s1.grd_wrappers.calibration
 
-.. automethod:: ost.s1.grd_wrappers.grd_frame_import
+.. autofunction:: ost.s1.grd_wrappers.grd_frame_import
 
-.. automethod:: ost.s1.grd_wrappers.grd_remove_border
+.. autofunction:: ost.s1.grd_wrappers.grd_remove_border
 
-.. automethod:: ost.s1.grd_wrappers.grd_subset_georegion
+.. autofunction:: ost.s1.grd_wrappers.grd_subset_georegion
 
-.. automethod:: ost.s1.grd_wrappers.multi_look
+.. autofunction:: ost.s1.grd_wrappers.multi_look
 
-.. automethod:: ost.s1.grd_wrappers.slice_assembly
+.. autofunction:: ost.s1.grd_wrappers.slice_assembly
 
 
    

--- a/docs/source/modules/ost.s1.refine_inventory.rst
+++ b/docs/source/modules/ost.s1.refine_inventory.rst
@@ -10,7 +10,7 @@ ost.s1.refine\_inventory
    
       search_refinement
 
-.. automethod:: ost.s1.refine_inventory.search_refinement
+.. autofunction:: ost.s1.refine_inventory.search_refinement
    
    
 

--- a/docs/source/modules/ost.s1.search.rst
+++ b/docs/source/modules/ost.s1.search.rst
@@ -11,9 +11,9 @@ ost.s1.search
       check_availability
       scihub_catalogue
 
-.. automethod:: ost.s1.search.check_availability
+.. autofunction:: ost.s1.search.check_availability
 
-.. automethod:: ost.s1.search.scihub_catalogue
+.. autofunction:: ost.s1.search.scihub_catalogue
    
    
 

--- a/docs/source/modules/ost.s1.slc_wrappers.rst
+++ b/docs/source/modules/ost.s1.slc_wrappers.rst
@@ -15,17 +15,17 @@ ost.s1.slc\_wrappers
       coreg2
       ha_alpha
 
-.. automethod:: ost.s1.slc_wrappers.burst_import
+.. autofunction:: ost.s1.slc_wrappers.burst_import
 
-.. automethod:: ost.s1.slc_wrappers.calibration
+.. autofunction:: ost.s1.slc_wrappers.calibration
 
-.. automethod:: ost.s1.slc_wrappers.coherence
+.. autofunction:: ost.s1.slc_wrappers.coherence
 
-.. automethod:: ost.s1.slc_wrappers.coreg
+.. autofunction:: ost.s1.slc_wrappers.coreg
 
-.. automethod:: ost.s1.slc_wrappers.coreg2
+.. autofunction:: ost.s1.slc_wrappers.coreg2
 
-.. automethod:: ost.s1.slc_wrappers.ha_alpha
+.. autofunction:: ost.s1.slc_wrappers.ha_alpha
 
    
    

--- a/docs/source/modules/ost.s1.ts.rst
+++ b/docs/source/modules/ost.s1.ts.rst
@@ -11,9 +11,9 @@ ost.s1.ts
       create_datelist
       create_ts_animation
 
-.. automethod:: ost.s1.ts.create_datelist
+.. autofunction:: ost.s1.ts.create_datelist
 
-.. automethod:: ost.s1.ts.create_ts_animation
+.. autofunction:: ost.s1.ts.create_ts_animation
 
 
    


### PR DESCRIPTION
Fix #77 

- We were using the `automethod` directive instead of the the `autofunction`. I changed it for the module function and kept it for the class methods
- Also remove the .vscode parameters 